### PR TITLE
Improve ship rotation and star field in GalaxyMap

### DIFF
--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -339,7 +339,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
     mapX.set(newMapX);
     mapY.set(newMapY);
 
-    // Rotação imediata e responsiva
+    // Rotação fluida e responsiva
     if (Math.sqrt(deltaX * deltaX + deltaY * deltaY) > 1) {
       setHasMoved(true);
       const newAngle = Math.atan2(-deltaY, -deltaX) * (180 / Math.PI) + 90;
@@ -354,8 +354,12 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
       if (diff > 180) diff -= 360;
       if (diff < -180) diff += 360;
 
-      // Aplica rotação direta para máxima performance
-      shipRotation.set(currentAngle + diff);
+      // Aplica rotação suave mas responsiva
+      const targetAngle = currentAngle + diff;
+      animate(shipRotation, targetAngle, {
+        duration: 0.08,
+        ease: [0.25, 0.46, 0.45, 0.94], // easeOutQuart para suavidade
+      });
     }
 
     lastMousePos.current = { x: e.clientX, y: e.clientY };
@@ -435,8 +439,12 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
         if (diff > 180) diff -= 360;
         if (diff < -180) diff += 360;
 
-        // Aplica rotação direta para máxima performance
-        shipRotation.set(currentAngle + diff);
+        // Aplica rotação suave mas responsiva
+        const targetAngle = currentAngle + diff;
+        animate(shipRotation, targetAngle, {
+          duration: 0.08,
+          ease: [0.25, 0.46, 0.45, 0.94], // easeOutQuart para suavidade
+        });
       }
 
       lastMousePos.current = { x: e.clientX, y: e.clientY };

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -350,9 +350,14 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
       if (angleDiff > 180) angleDiff -= 360;
       if (angleDiff < -180) angleDiff += 360;
 
-      // Aplica a rotação suave tomando o caminho mais curto
-      const targetAngle = currentAngle + angleDiff;
-      animate(shipRotation, targetAngle, { duration: 0.05, ease: "easeOut" });
+      // Se o ângulo tem wrap (mudança grande), usa animação muito rápida
+      // Caso contrário, aplica direto para máxima responsividade
+      if (Math.abs(angleDiff) > 120) {
+        const targetAngle = currentAngle + angleDiff;
+        animate(shipRotation, targetAngle, { duration: 0.01, ease: "linear" });
+      } else {
+        shipRotation.set(newAngle);
+      }
     }
 
     lastMousePos.current = { x: e.clientX, y: e.clientY };
@@ -428,9 +433,17 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
         if (angleDiff > 180) angleDiff -= 360;
         if (angleDiff < -180) angleDiff += 360;
 
-        // Aplica a rotação suave tomando o caminho mais curto
-        const targetAngle = currentAngle + angleDiff;
-        animate(shipRotation, targetAngle, { duration: 0.05, ease: "easeOut" });
+        // Se o ângulo tem wrap (mudança grande), usa animação muito rápida
+        // Caso contrário, aplica direto para máxima responsividade
+        if (Math.abs(angleDiff) > 120) {
+          const targetAngle = currentAngle + angleDiff;
+          animate(shipRotation, targetAngle, {
+            duration: 0.01,
+            ease: "linear",
+          });
+        } else {
+          shipRotation.set(newAngle);
+        }
       }
 
       lastMousePos.current = { x: e.clientX, y: e.clientY };

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -192,11 +192,15 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
     velocityRef.current = velocity;
   }, [velocity]);
 
-  // Sistema de rotação suave com interpolação contínua
+  // Sistema de rotação suave com interpolação adaptativa ao refresh rate
   useEffect(() => {
     let animationId: number;
+    let lastFrameTime = performance.now();
 
-    const smoothRotation = () => {
+    const smoothRotation = (currentTime: number) => {
+      const deltaTime = currentTime - lastFrameTime;
+      lastFrameTime = currentTime;
+
       const currentAngle = shipRotation.get();
       const target = targetRotation.current;
 
@@ -209,9 +213,14 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
       if (diff > 180) diff -= 360;
       if (diff < -180) diff += 360;
 
-      // Interpolação suave mas responsiva
-      const lerpFactor = 0.15; // Ajuste para responsividade vs suavidade
-      const newAngle = currentAngle + diff * lerpFactor;
+      // Interpolação adaptativa ao refresh rate (60fps, 120fps, 144fps, etc.)
+      // Factor baseado em 60fps como baseline (16.67ms)
+      const baseFrameTime = 16.67;
+      const timeAdjustedFactor = Math.min(
+        1,
+        (deltaTime / baseFrameTime) * 0.25,
+      );
+      const newAngle = currentAngle + diff * timeAdjustedFactor;
 
       shipRotation.set(newAngle);
 

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -345,19 +345,17 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
       const newAngle = Math.atan2(-deltaY, -deltaX) * (180 / Math.PI) + 90;
       const currentAngle = shipRotation.get();
 
-      // Calcula a diferença angular considerando wrap de 360°
-      let angleDiff = newAngle - currentAngle;
-      if (angleDiff > 180) angleDiff -= 360;
-      if (angleDiff < -180) angleDiff += 360;
+      // Normaliza ângulos para evitar saltos visuais
+      let normalizedNew = ((newAngle % 360) + 360) % 360;
+      let normalizedCurrent = ((currentAngle % 360) + 360) % 360;
 
-      // Se o ângulo tem wrap (mudança grande), usa animação muito rápida
-      // Caso contrário, aplica direto para máxima responsividade
-      if (Math.abs(angleDiff) > 120) {
-        const targetAngle = currentAngle + angleDiff;
-        animate(shipRotation, targetAngle, { duration: 0.01, ease: "linear" });
-      } else {
-        shipRotation.set(newAngle);
-      }
+      // Calcula a diferença usando o caminho mais curto
+      let diff = normalizedNew - normalizedCurrent;
+      if (diff > 180) diff -= 360;
+      if (diff < -180) diff += 360;
+
+      // Aplica rotação direta para máxima performance
+      shipRotation.set(currentAngle + diff);
     }
 
     lastMousePos.current = { x: e.clientX, y: e.clientY };
@@ -428,22 +426,17 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
         const newAngle = Math.atan2(-deltaY, -deltaX) * (180 / Math.PI) + 90;
         const currentAngle = shipRotation.get();
 
-        // Calcula a diferença angular considerando wrap de 360°
-        let angleDiff = newAngle - currentAngle;
-        if (angleDiff > 180) angleDiff -= 360;
-        if (angleDiff < -180) angleDiff += 360;
+        // Normaliza ângulos para evitar saltos visuais
+        let normalizedNew = ((newAngle % 360) + 360) % 360;
+        let normalizedCurrent = ((currentAngle % 360) + 360) % 360;
 
-        // Se o ângulo tem wrap (mudança grande), usa animação muito rápida
-        // Caso contrário, aplica direto para máxima responsividade
-        if (Math.abs(angleDiff) > 120) {
-          const targetAngle = currentAngle + angleDiff;
-          animate(shipRotation, targetAngle, {
-            duration: 0.01,
-            ease: "linear",
-          });
-        } else {
-          shipRotation.set(newAngle);
-        }
+        // Calcula a diferença usando o caminho mais curto
+        let diff = normalizedNew - normalizedCurrent;
+        if (diff > 180) diff -= 360;
+        if (diff < -180) diff += 360;
+
+        // Aplica rotação direta para máxima performance
+        shipRotation.set(currentAngle + diff);
       }
 
       lastMousePos.current = { x: e.clientX, y: e.clientY };

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -342,8 +342,17 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
     // Rotação imediata e responsiva
     if (Math.sqrt(deltaX * deltaX + deltaY * deltaY) > 1) {
       setHasMoved(true);
-      const angle = Math.atan2(-deltaY, -deltaX) * (180 / Math.PI) + 90;
-      shipRotation.set(angle); // Rotação imediata sem animação
+      const newAngle = Math.atan2(-deltaY, -deltaX) * (180 / Math.PI) + 90;
+      const currentAngle = shipRotation.get();
+
+      // Calcula a diferença angular considerando wrap de 360°
+      let angleDiff = newAngle - currentAngle;
+      if (angleDiff > 180) angleDiff -= 360;
+      if (angleDiff < -180) angleDiff += 360;
+
+      // Aplica a rotação suave tomando o caminho mais curto
+      const targetAngle = currentAngle + angleDiff;
+      animate(shipRotation, targetAngle, { duration: 0.05, ease: "easeOut" });
     }
 
     lastMousePos.current = { x: e.clientX, y: e.clientY };
@@ -411,8 +420,17 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
 
       if (Math.sqrt(deltaX * deltaX + deltaY * deltaY) > 1) {
         setHasMoved(true);
-        const angle = Math.atan2(-deltaY, -deltaX) * (180 / Math.PI) + 90;
-        shipRotation.set(angle); // Rotação imediata sem animação
+        const newAngle = Math.atan2(-deltaY, -deltaX) * (180 / Math.PI) + 90;
+        const currentAngle = shipRotation.get();
+
+        // Calcula a diferença angular considerando wrap de 360°
+        let angleDiff = newAngle - currentAngle;
+        if (angleDiff > 180) angleDiff -= 360;
+        if (angleDiff < -180) angleDiff += 360;
+
+        // Aplica a rotação suave tomando o caminho mais curto
+        const targetAngle = currentAngle + angleDiff;
+        animate(shipRotation, targetAngle, { duration: 0.05, ease: "easeOut" });
       }
 
       lastMousePos.current = { x: e.clientX, y: e.clientY };

--- a/src/components/World/PlayerShip.tsx
+++ b/src/components/World/PlayerShip.tsx
@@ -20,8 +20,15 @@ export const PlayerShip: React.FC<PlayerShipProps> = ({
       style={{ rotate: rotation }}
       animate={{
         scale: isDragging ? 1.1 : 1,
+        // Vibração sutil quando ligada (sempre ativa)
+        x: isDragging ? 0 : [0, 0.3, 0, -0.3, 0],
+        y: isDragging ? 0 : [0, -0.2, 0, 0.2, 0],
       }}
-      transition={{ type: "spring", stiffness: 300, damping: 30 }}
+      transition={{
+        scale: { type: "spring", stiffness: 300, damping: 30 },
+        x: { duration: 2, repeat: Infinity, ease: "easeInOut" },
+        y: { duration: 1.8, repeat: Infinity, ease: "easeInOut" },
+      }}
     >
       {/* Spaceship Image */}
       <motion.img
@@ -33,17 +40,17 @@ export const PlayerShip: React.FC<PlayerShipProps> = ({
         }}
       />
 
-      {/* Ship trails - positioned at the back of the ship */}
-      {(isDragging || isDecelerating) && (
+      {/* Ship trails - apenas quando arrastando */}
+      {isDragging && (
         <>
           <motion.div
             className="absolute top-full left-1/2 w-0.5 h-4 bg-gradient-to-t from-transparent to-blue-400 transform -translate-x-1/2"
             animate={{
-              opacity: isDragging ? [0.3, 0.8, 0.3] : [0.8, 0.2, 0.8],
-              scaleY: isDragging ? [0.5, 1, 0.5] : [1, 0.3, 1],
+              opacity: [0.3, 0.8, 0.3],
+              scaleY: [0.5, 1, 0.5],
             }}
             transition={{
-              duration: isDragging ? 0.5 : 1.0,
+              duration: 0.5,
               repeat: Infinity,
               ease: "easeInOut",
             }}
@@ -51,49 +58,17 @@ export const PlayerShip: React.FC<PlayerShipProps> = ({
           <motion.div
             className="absolute top-full left-1/2 w-0.5 h-3 bg-gradient-to-t from-transparent to-cyan-300 transform -translate-x-1/2 translate-y-1"
             animate={{
-              opacity: isDragging ? [0.2, 0.6, 0.2] : [0.6, 0.1, 0.6],
-              scaleY: isDragging ? [0.3, 1, 0.3] : [1, 0.2, 1],
+              opacity: [0.2, 0.6, 0.2],
+              scaleY: [0.3, 1, 0.3],
             }}
             transition={{
-              duration: isDragging ? 0.3 : 0.8,
+              duration: 0.3,
               repeat: Infinity,
               ease: "easeInOut",
               delay: 0.1,
             }}
           />
         </>
-      )}
-
-      {/* Efeito de momentum - partículas sutis quando em desaceleração */}
-      {isDecelerating && (
-        <motion.div
-          className="absolute top-full left-1/2 transform -translate-x-1/2"
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0 }}
-        >
-          {[...Array(3)].map((_, i) => (
-            <motion.div
-              key={i}
-              className="absolute w-0.5 h-0.5 bg-blue-300 rounded-full"
-              style={{
-                left: `${(i - 1) * 3}px`,
-                top: `${i * 2 + 2}px`,
-              }}
-              animate={{
-                opacity: [0, 0.6, 0],
-                scale: [0, 1, 0],
-                y: [0, 8, 16],
-              }}
-              transition={{
-                duration: 1.2,
-                repeat: Infinity,
-                delay: i * 0.2,
-                ease: "easeOut",
-              }}
-            />
-          ))}
-        </motion.div>
       )}
     </motion.div>
   );


### PR DESCRIPTION
Enhances the GalaxyMap component with smoother ship rotation and expanded star field:

**Ship Rotation System:**
- Implements smooth rotation interpolation with adaptive refresh rate support
- Adds targetRotation ref system for smoother angle transitions
- Normalizes angles and calculates shortest rotation path
- Uses requestAnimationFrame for consistent rotation updates

**Star Field Improvements:**
- Increases star count from 400 to 800 for denser coverage
- Expands star positioning from 100% to 150% to cover beyond borders
- Updates star layer containers to use -inset-1/4 for better coverage

**Movement Detection:**
- Adds hasMoved state to distinguish between clicks and drags
- Stops momentum completely on simple clicks (no movement)
- Reduces movement threshold from 2 to 1 pixel for more responsive rotation

**PlayerShip Component:**
- Adds subtle idle vibration animation when not dragging
- Simplifies trail effects to only show when actively dragging
- Removes momentum particle effects during deceleration

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/fac98a73580e4f548c6e8d8ee2bf807a/zen-haven)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>fac98a73580e4f548c6e8d8ee2bf807a</projectId>-->
<!--<branchName>zen-haven</branchName>-->