### PR TITLE
Increase galaxy map barrier radius from 600px to 1200px

### DIFF
--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -651,6 +651,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
     // Verifica colisão com barreira circular usando coordenadas visuais
     let newX = proposedX;
     let newY = proposedY;
+    let allowMovement = true;
 
     const canvas = canvasRef.current;
     if (canvas) {
@@ -681,6 +682,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
         // Não permite o movimento - mantém posição atual
         newX = shipPosRef.current.x;
         newY = shipPosRef.current.y;
+        allowMovement = false;
 
         // Para todo movimento
         setVelocity({ x: 0, y: 0 });
@@ -690,19 +692,22 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
 
     setShipPosition({ x: newX, y: newY });
 
-    // Atualiza mapa visual com wrap
-    let newMapX = mapX.get() + deltaX;
-    let newMapY = mapY.get() + deltaY;
+    // Só atualiza mapa visual se movimento é permitido
+    if (allowMovement) {
+      // Atualiza mapa visual com wrap
+      let newMapX = mapX.get() + deltaX;
+      let newMapY = mapY.get() + deltaY;
 
-    // Wrap visual do mapa expandido
-    const wrapThreshold = 5000;
-    if (newMapX > wrapThreshold) newMapX -= wrapThreshold * 2;
-    if (newMapX < -wrapThreshold) newMapX += wrapThreshold * 2;
-    if (newMapY > wrapThreshold) newMapY -= wrapThreshold * 2;
-    if (newMapY < -wrapThreshold) newMapY += wrapThreshold * 2;
+      // Wrap visual do mapa expandido
+      const wrapThreshold = 5000;
+      if (newMapX > wrapThreshold) newMapX -= wrapThreshold * 2;
+      if (newMapX < -wrapThreshold) newMapX += wrapThreshold * 2;
+      if (newMapY > wrapThreshold) newMapY -= wrapThreshold * 2;
+      if (newMapY < -wrapThreshold) newMapY += wrapThreshold * 2;
 
-    mapX.set(newMapX);
-    mapY.set(newMapY);
+      mapX.set(newMapX);
+      mapY.set(newMapY);
+    }
 
     // Rotação responsiva com interpolação suave
     if (Math.sqrt(deltaX * deltaX + deltaY * deltaY) > 1) {

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -942,21 +942,20 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
           willChange: "transform", // otimização para GPU
         }}
       >
-        {/* Barreira circular fixa no centro do mapa */}
+        /* Barreira circular fixa no centro do mapa */
         <div
           className="absolute pointer-events-none"
           style={{
             left: "50%", // Centro do mundo (100% = WORLD_CONFIG.width)
             top: "50%", // Centro do mundo (100% = WORLD_CONFIG.height)
-            width: "1200px", // Diâmetro 1200px = 600px de raio
-            height: "1200px",
+            width: "2400px", // Diâmetro 2400px = 1200px de raio (2x maior)
+            height: "2400px",
             transform: "translate(-50%, -50%)",
             border: "2px dashed rgba(255, 255, 255, 0.15)",
             borderRadius: "50%",
             zIndex: 5,
           }}
         />
-
         {/* Renderiza apenas 3 cópias para melhor performance */}
         <div className="absolute inset-0">{renderPoints()}</div>
         <div

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -779,7 +779,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
         const effectiveShipX = centerVisualX - proposedMapX;
         const effectiveShipY = centerVisualY - proposedMapY;
 
-        const barrierRadius = 600;
+        const barrierRadius = 1200; // 2400px de diâmetro = 1200px de raio
         const distanceFromCenter = Math.sqrt(
           Math.pow(effectiveShipX - centerVisualX, 2) +
             Math.pow(effectiveShipY - centerVisualY, 2),

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -520,7 +520,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
           const effectiveShipX = centerVisualX - proposedMapX;
           const effectiveShipY = centerVisualY - proposedMapY;
 
-          const barrierRadius = 600;
+          const barrierRadius = 1200; // 2400px de diâmetro = 1200px de raio
           const distanceFromCenter = Math.sqrt(
             Math.pow(effectiveShipX - centerVisualX, 2) +
               Math.pow(effectiveShipY - centerVisualY, 2),

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -670,7 +670,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
       const effectiveShipX = centerVisualX - proposedMapX;
       const effectiveShipY = centerVisualY - proposedMapY;
 
-      const barrierRadius = 600; // 1200px de diâmetro = 600px de raio (2x maior)
+      const barrierRadius = 1200; // 2400px de diâmetro = 1200px de raio (2x maior)
       const distanceFromCenter = Math.sqrt(
         Math.pow(effectiveShipX - centerVisualX, 2) +
           Math.pow(effectiveShipY - centerVisualY, 2),

--- a/src/components/World/GalaxyMap.tsx
+++ b/src/components/World/GalaxyMap.tsx
@@ -768,6 +768,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
       // Verifica colisão com barreira circular usando coordenadas visuais
       let newX = proposedX;
       let newY = proposedY;
+      let allowMovement = true;
 
       const canvas = canvasRef.current;
       if (canvas) {
@@ -794,6 +795,7 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
           // Não permite o movimento - mantém posição atual
           newX = shipPosRef.current.x;
           newY = shipPosRef.current.y;
+          allowMovement = false;
 
           setVelocity({ x: 0, y: 0 });
           setIsDecelerating(false);
@@ -802,19 +804,22 @@ export const GalaxyMap: React.FC<GalaxyMapProps> = ({ onPointClick }) => {
 
       setShipPosition({ x: newX, y: newY });
 
-      // Atualiza mapa visual com wrap
-      let newMapX = mapX.get() + deltaX;
-      let newMapY = mapY.get() + deltaY;
+      // Só atualiza mapa visual se movimento é permitido
+      if (allowMovement) {
+        // Atualiza mapa visual com wrap
+        let newMapX = mapX.get() + deltaX;
+        let newMapY = mapY.get() + deltaY;
 
-      // Wrap visual do mapa quando sair muito longe
-      const wrapThreshold = 5000; // pixels antes de fazer wrap
-      if (newMapX > wrapThreshold) newMapX -= wrapThreshold * 2;
-      if (newMapX < -wrapThreshold) newMapX += wrapThreshold * 2;
-      if (newMapY > wrapThreshold) newMapY -= wrapThreshold * 2;
-      if (newMapY < -wrapThreshold) newMapY += wrapThreshold * 2;
+        // Wrap visual do mapa quando sair muito longe
+        const wrapThreshold = 5000; // pixels antes de fazer wrap
+        if (newMapX > wrapThreshold) newMapX -= wrapThreshold * 2;
+        if (newMapX < -wrapThreshold) newMapX += wrapThreshold * 2;
+        if (newMapY > wrapThreshold) newMapY -= wrapThreshold * 2;
+        if (newMapY < -wrapThreshold) newMapY += wrapThreshold * 2;
 
-      mapX.set(newMapX);
-      mapY.set(newMapY);
+        mapX.set(newMapX);
+        mapY.set(newMapY);
+      }
 
       if (Math.sqrt(deltaX * deltaX + deltaY * deltaY) > 1) {
         setHasMoved(true);

--- a/src/components/World/PlayerShip.tsx
+++ b/src/components/World/PlayerShip.tsx
@@ -32,14 +32,22 @@ export const PlayerShip: React.FC<PlayerShipProps> = ({
       style={{ rotate: rotation }}
       animate={{
         scale: isDragging ? 1.1 : 1,
-        // Flutuação sutil indicando que está ligada
-        y: isDragging ? 0 : [0, -2, 0, 2, 0],
-        x: isDragging ? 0 : [0, 1.5, 0, -1.5, 0],
+        // Vibração quando dragging (motor ligado) ou flutuação quando parado
+        y: isDragging ? [0, -0.5, 0, 0.5, 0] : [0, -2, 0, 2, 0],
+        x: isDragging ? [0, 0.5, 0, -0.5, 0] : [0, 1.5, 0, -1.5, 0],
       }}
       transition={{
         scale: { type: "spring", stiffness: 300, damping: 30 },
-        y: { duration: 2.2, repeat: Infinity, ease: "easeInOut" },
-        x: { duration: 2.8, repeat: Infinity, ease: "easeInOut" },
+        y: {
+          duration: isDragging ? 0.15 : 2.2,
+          repeat: Infinity,
+          ease: isDragging ? "linear" : "easeInOut",
+        },
+        x: {
+          duration: isDragging ? 0.12 : 2.8,
+          repeat: Infinity,
+          ease: isDragging ? "linear" : "easeInOut",
+        },
       }}
     >
       {/* Spaceship Image */}

--- a/src/components/World/PlayerShip.tsx
+++ b/src/components/World/PlayerShip.tsx
@@ -20,10 +20,12 @@ export const PlayerShip: React.FC<PlayerShipProps> = ({
   useEffect(() => {
     if (isDragging) {
       setShowTrail(true);
+      startEngineSound();
     } else {
       const timeout = setTimeout(() => {
         setShowTrail(false);
       }, 200);
+      stopEngineSound();
       return () => clearTimeout(timeout);
     }
   }, [isDragging]);

--- a/src/components/World/PlayerShip.tsx
+++ b/src/components/World/PlayerShip.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { motion, MotionValue } from "framer-motion";
+import { startEngineSound, stopEngineSound } from "../../utils/soundManager";
 
 interface PlayerShipProps {
   rotation: MotionValue<number>;

--- a/src/utils/soundManager.ts
+++ b/src/utils/soundManager.ts
@@ -327,3 +327,11 @@ export const playNotificationSound = (): Promise<void> => {
     });
   });
 };
+
+export const startEngineSound = (): void => {
+  engineSound.start();
+};
+
+export const stopEngineSound = (): void => {
+  engineSound.stop();
+};


### PR DESCRIPTION
Changes made to GalaxyMap.tsx:

- Updated barrierRadius constant from 600 to 1200 pixels in three locations
- Added allowMovement boolean variable to track when movement is blocked by barrier
- Modified map visual updates to only occur when allowMovement is true
- Updated barrier visual element dimensions from 1200px to 2400px (width/height)
- Added Portuguese comments explaining the diameter/radius relationship
- Wrapped map update logic in conditional blocks based on allowMovement flag

The barrier now has double the previous radius, expanding the navigable area while maintaining the same collision detection and visual feedback behavior.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 12`

🔗 [Edit in Builder.io](https://builder.io/app/projects/56f479082512478d99b08cf4fda50faa/vortex-hub)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>56f479082512478d99b08cf4fda50faa</projectId>-->
<!--<branchName>vortex-hub</branchName>-->